### PR TITLE
Installationsskript für die Klassen auf Unix-Systemen

### DIFF
--- a/update_classes.sh
+++ b/update_classes.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+topdir=`dirname $0`
+cd "$topdir"
+if [ -d temp ]
+then
+    rm -rf temp 
+fi
+cp -r source temp
+mkdir -p temp/tex/latex/tudscr
+cp -r source/logo temp/tex/latex/tudscr
+cd temp
+cat > docstrip.cfg <<EOF
+\BaseDirectory{.}
+\UseTDS
+EOF
+tex tudscr.ins
+texmfpath=`kpsewhich --var-value=TEXMFHOME|sed 's,^!*,,'`
+cp -r tex "$texmfpath" 
+cd "$topdir"
+if [ -d temp ]
+then
+    rm -rf temp 
+fi
+# Wenn keine ls-R-Datei existiert möchte der 
+# Nutzer eventuell auch keine haben, um neue 
+# oder gelöschte Dateien schnell und fehlerfrei
+# zur Verfügung zu haben.
+test -f "$texmfpath/ls-R" && mktexlsr "$texmfpath"


### PR DESCRIPTION
Unterschiede zur normalen Batch-Datei:
• Ausrufezeichen am Anfang von $TEXMFHOME werden beim Kopieren ignoriert
• mktexlsr wird nur aufgerufen, wenn schon eine ls-R-Datei vorhanden ist.
  Andernfalls müssen wir davon ausgehen, dass der Nutzer sein
  texmf-Verzeichnis nicht indiziert haben möchte, um flexibel Änderungen
  am Verzeichnisinhalt vornehmen zu können.