### PR TITLE
Update tudscr-installation.tex

### DIFF
--- a/source/doc/tudscr-installation.tex
+++ b/source/doc/tudscr-installation.tex
@@ -203,7 +203,7 @@ Verzeichnis befinden:
     (Terminal: \Path{bash tudscr\_\vTUDScript\_install.sh})
   \item[\File{Univers\_PS.zip}]Archiv mit Schriftdateien für \Univers
   \item[\File{DIN\_Bd\_PS.zip}]Archiv mit Schriftdateien für \DIN
-  \item[\File{tudscrfonts.zip}]Archiv mit Metriken für die
+  \item[\File{tudscr_fonts_install.zip}]Archiv mit Metriken für die
     Schriftinstallation via \Package{fontinst}
 \end{description}
 %


### PR DESCRIPTION
filename is `tudscr_fonts_install.zip` and not `tudscrfonts.zip` in the zip package `TUD-KOMA-Script_fonts_Unix.zip` downloaded from https://github.com/tud-cd/tudscr/releases/download/fonts/TUD-KOMA-Script_fonts_Unix.zip