### PR TITLE
fix typo in text of confirmation

### DIFF
--- a/source/tudscr-localization.dtx
+++ b/source/tudscr-localization.dtx
@@ -609,7 +609,7 @@
 \tud@localization@german{\confirmationname}{Selbstst\"andigkeitserkl\"arung}%
 \tud@localization@german{\confirmationtext}{%
   Hiermit versichere ich, dass ich die vorliegende Arbeit 
-  \ifx\@@title\@empty\else mit dem Titel \emph{\@@title} \fi
+  \ifx\@@title\@empty\else{} mit dem Titel \emph{\@@title} \fi
   selbstst\"andig und ohne unzul\"assige Hilfe Dritter verfasst habe. 
   Es wurden keine anderen als die in der Arbeit angegebenen Hilfsmittel 
   und Quellen benutzt. Die w\"ortlichen und sinngem\"a\ss{} 
@@ -630,7 +630,7 @@
 \tud@localization@german{\blockingname}{Sperrvermerk}%
 \tud@localization@german{\blockingtext}{%
   Diese Arbeit 
-  \ifx\@@title\@empty\else mit dem Titel \emph{\@@title} \fi
+  \ifx\@@title\@empty\else{} mit dem Titel \emph{\@@title} \fi
   enth\"alt vertrauliche Informationen\ifx\@company\@empty\else
   , offengelegt durch \emph{\@company}\fi. Ver\"offentlichungen, 
   Vervielf\"altigungen und Einsichtnahme~-- auch nur auszugsweise~-- 
@@ -833,7 +833,7 @@
 \tud@localization@english{\confirmationtext}{%
   I hereby certify that I have authored this 
   \ifx\@@thesis\@empty thesis\else\@@thesis{} \fi
-  \ifx\@@title\@empty\else entitled \emph{\@@title} \fi
+  \ifx\@@title\@empty\else{} entitled \emph{\@@title} \fi
   independently and without undue assistance from third 
   parties. No other than the resources and references 
   indicated in this thesis have been used. I have marked 
@@ -854,7 +854,7 @@
 \tud@localization@english{\blockingname}{Restriction note}%
 \tud@localization@english{\blockingtext}{%
   This \ifx\@@thesis\@empty thesis \else\@@thesis{} \fi
-  \ifx\@@title\@empty\else entitled \emph{\@@title} \fi
+  \ifx\@@title\@empty\else{} entitled \emph{\@@title} \fi
   contains confidential data\ifx\@company\@empty\else
   , disclosed by \emph{\@company}\fi. Publications, duplications 
   and inspections---even in part---are prohibited without explicit 

--- a/source/tudscr-localization.dtx
+++ b/source/tudscr-localization.dtx
@@ -832,7 +832,7 @@
 \tud@localization@english{\confirmationname}{Statement of authorship}%
 \tud@localization@english{\confirmationtext}{%
   I hereby certify that I have authored this 
-  \ifx\@@thesis\@empty thesis\else\@@thesis{} \fi
+  \ifx\@@thesis\@empty thesis \else\@@thesis{} \fi
   \ifx\@@title\@empty\else{} entitled \emph{\@@title} \fi
   independently and without undue assistance from third 
   parties. No other than the resources and references 


### PR DESCRIPTION
missing {} after else clause caused missing space