### PR TITLE
fix incorrect english translation of Bachelor-Arbeit and Master-Arbeit

### DIFF
--- a/source/tudscr-localization.dtx
+++ b/source/tudscr-localization.dtx
@@ -855,8 +855,8 @@
 \tud@localization@english{\habilitationname}{Habilitation}
 \tud@localization@english{\dissertationname}{Dissertation}
 \tud@localization@english{\diplomathesisname}{Diploma Thesis}
-\tud@localization@english{\masterthesisname}{Master Thesis}
-\tud@localization@english{\bachelorthesisname}{Bachelor Thesis}
+\tud@localization@english{\masterthesisname}{Master's Thesis}
+\tud@localization@english{\bachelorthesisname}{Bachelor's Thesis}
 \tud@localization@english{\studentthesisname}{Student Thesis}
 \tud@localization@english{\studentresearchname}{Student Research Project}
 \tud@localization@english{\projectpapername}{Project Paper}


### PR DESCRIPTION
The correct English translations are Bachelor's Thesis and Master's Thesis.

In case of doubt, feel free to contact the TUD Translation Office, https://tu-dresden.de/dezernat-7 ;).